### PR TITLE
4 lint and slight refactor, updates to work with new birdnet output format

### DIFF
--- a/assess_birdnet/aggregate_audio_analysis.py
+++ b/assess_birdnet/aggregate_audio_analysis.py
@@ -2,13 +2,11 @@
 
 Script for combining the batch out output files that Birdnet (acoustic bird
 species classification model) produces into one master csv including the file
-name of the file that the information came from.
+name of the file that the information came from. Needed if the .wav file
+needed to be split into smaller segments for processing.
 
-Args: Path to the directory containing the text files
-Output: A csv with all of the birdnet results from running analysis on
-multiple recordings, ignoring files that had 0 detections
-
-python aggregate_audio_analysis.py /path/to/input/dir
+Example:
+    $ python aggregate_audio_analysis.py /path/to/input/dir
 
 """
 import os
@@ -17,10 +15,13 @@ import argparse
 
 
 def main(root_dir):
-    """Main function that creates a CSV and populates it with the detection
+    """Aggregate birdnet results.
+
+    Main function that creates a CSV and populates it with the detection
     information from Birdnet text file outputs
 
-    Args: Path to directpry containing Birdnet results
+    Args:
+        root_dir (str): The path to directory containing Birdnet results
 
     """
     # Scanning the root directory containing sub-direcctories
@@ -78,7 +79,9 @@ if __name__ == '__main__':
         )
 
     # Create and parse arguements
-    parser.add_argument('root_dir', type=str, help='Directory path to files')
+    parser.add_argument('root_dir',
+                        type=str,
+                        help='Directory path to files')
     # Parse the command-line arguments
     args = parser.parse_args()
 

--- a/assess_birdnet/aggregate_audio_analysis.py
+++ b/assess_birdnet/aggregate_audio_analysis.py
@@ -1,8 +1,28 @@
+"""Aggregate Birdnet Output Files
+
+Script for combining the batch out output files that Birdnet (acoustic bird
+species classification model) produces into one master csv including the file
+name of the file that the information came from.
+
+Args: Path to the directory containing the text files
+Output: A csv with all of the birdnet results from running analysis on
+multiple recordings, ignoring files that had 0 detections
+
+python aggregate_audio_analysis.py /path/to/input/dir
+
+"""
 import os
 import csv
 import argparse
 
+
 def main(root_dir):
+    """Main function that creates a CSV and populates it with the detection
+    information from Birdnet text file outputs
+
+    Args: Path to directpry containing Birdnet results
+
+    """
     # Scanning the root directory containing sub-direcctories
     for root, _, _ in os.walk(root_dir):
         # Get a list of all .txt files in each current directory
@@ -14,35 +34,49 @@ def main(root_dir):
             subdirectory_name = os.path.basename(root)
 
             # Create the CSV file for the current folder
-            output_csv_file = os.path.join(root, f"{subdirectory_name}_master.csv")
+            output_csv_file = os.path.join(root,
+                                           f"{subdirectory_name}_master.csv")
             csv_headers = [
-                "Selection", "View", "Channel", "Begin Time (s)", "End Time (s)", 
-                "Low Freq (Hz)", "High Freq (Hz)", "Species Code", "Common Name", "Confidence", "File Name"
+                "Selection",
+                "View",
+                "Channel",
+                "Begin Time (s)",
+                "End Time (s)",
+                "Low Freq (Hz)",
+                "High Freq (Hz)", "Species Code",
+                "Common Name",
+                "Confidence",
+                "File Name"
             ]
 
-            with open(output_csv_file, mode='w', newline='') as csvfile:
+            with open(
+                output_csv_file, mode='w', newline='', encoding='utf8'
+            ) as csvfile:
                 csv_writer = csv.writer(csvfile)
                 csv_writer.writerow(csv_headers)
 
                 for txt_file in sorted_txt_files:
-                    with open(os.path.join(root, txt_file), 'r') as txtfile:
-                        lines = txtfile.readlines()[1:]  # Ignoring the *individual headers
+                    with open(
+                        os.path.join(root, txt_file), 'r', encoding='utf8'
+                    ) as txtfile:
+                        lines = txtfile.readlines()[1:]
                         for line in lines:
                             data = line.strip().split('\t')
                             file_name = os.path.splitext(txt_file)[0]
-                            data.append(file_name)  # Adding the file name to the data
+                            data.append(file_name)
                             csv_writer.writerow(data)
 
-            print(f"Master CSV file for directory '{root}' created successfully.")
+            print(f"File for directory '{root}' created successfully.")
+
 
 if __name__ == '__main__':
     # Create an argument parser
     parser = argparse.ArgumentParser(
-        description='Input and Output Directory Paths  for Audio Files Aggregation'
+        description='Input Directory Path'
         )
 
     # Create and parse arguements
-    parser.add_argument('root_dir', type=str, help='Path to Root Directory containing sub directories with audio files and corresponding txt files')
+    parser.add_argument('root_dir', type=str, help='Directory path to files')
     # Parse the command-line arguments
     args = parser.parse_args()
 

--- a/assess_birdnet/aggregate_audio_analysis.py
+++ b/assess_birdnet/aggregate_audio_analysis.py
@@ -46,7 +46,9 @@ def main(root_dir):
                 "High Freq (Hz)", "Species Code",
                 "Common Name",
                 "Confidence",
-                "File Name"
+                "File Name",
+                "Extra 1",
+                "Extra 2"
             ]
 
             with open(
@@ -66,7 +68,7 @@ def main(root_dir):
                             data.append(file_name)
                             csv_writer.writerow(data)
 
-            print(f"File for directory '{root}' created successfully.")
+            print(f"File '{output_csv_file}' created successfully.")
 
 
 if __name__ == '__main__':

--- a/assess_birdnet/assess_performance.py
+++ b/assess_birdnet/assess_performance.py
@@ -1,11 +1,13 @@
 """Script to Evaluate Birdnet
 
-   This script compares human and birdnet labels and outputs the
-   confusion matrix, accuracy, precision, recall, and F1 score
-   assuming the human labels are 100% accurate.
+This script compares human and birdnet labels and outputs the
+confusion matrix, accuracy, precision, recall, and F1 score
+assuming the human labels are 100% accurate.
 
-assess_performance.py /path/to/human_labeled.csv /path/to/birdnet_labeled.csv
+Example:
+    $ python assess_performance.py /path/to/human_labeled.csv /path/to/birdnet_labeled.csv
 
+# pylint: disable=line-too-long
 """
 import argparse
 import pandas as pd
@@ -14,10 +16,13 @@ from sklearn.metrics import recall_score, f1_score
 
 
 def main(human_labeled, birdnet_labeled):
-    """Main script that prints metrics comparing human/birdnet labeled
-    acoustic data assuming the human labels are ground truth
+    """Evaluate Birdnet metrics
+    Main script that prints metrics comparing human/birdnet labeled
+    acoustic data assuming the human labels are ground truth.
 
-    Args: path to human labeled csv, path to birdnet labeled csv
+    Args:
+        human_labeled (str): The path to the human labeled csv.
+        birdnet_labeled (str): The path to the adjusted birdnet output.
     """
     scored_data = pd.read_csv(human_labeled)
     ml_output = pd.read_csv(birdnet_labeled)
@@ -43,9 +48,11 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Input Directory Path'
         )
-    parser.add_argument('human_labeled', type=str,
+    parser.add_argument('human_labeled',
+                        type=str,
                         help='Path to human labeled adjusted output')
-    parser.add_argument('birdnet_labeled', type=str,
+    parser.add_argument('birdnet_labeled',
+                        type=str,
                         help='Path to birdnet labeled adjusted output')
     args = parser.parse_args()
     main(args.human_labeled, args.birdnet_labeled)

--- a/assess_birdnet/assess_performance.py
+++ b/assess_birdnet/assess_performance.py
@@ -1,23 +1,51 @@
+"""Script to Evaluate Birdnet
+
+   This script compares human and birdnet labels and outputs the
+   confusion matrix, accuracy, precision, recall, and F1 score
+   assuming the human labels are 100% accurate.
+
+assess_performance.py /path/to/human_labeled.csv /path/to/birdnet_labeled.csv
+
+"""
+import argparse
 import pandas as pd
-from sklearn.metrics import confusion_matrix, accuracy_score, precision_score, recall_score, f1_score
-
-scored_data = pd.read_csv('/home/katie/Desktop/BirdNET-Analyzer/formatted_data_for_20170422_180000.csv')
-ml_output = pd.read_csv('/home/katie/Desktop/BirdNET-Analyzer/adjusted_ml_output.csv')
+from sklearn.metrics import confusion_matrix, accuracy_score, precision_score
+from sklearn.metrics import recall_score, f1_score
 
 
-y_true = scored_data['Label'].map({'yes': 1, 'no': 0}).values
-y_pred = ml_output['Label'].map({'yes': 1, 'no': 0}).values
+def main(human_labeled, birdnet_labeled):
+    """Main script that prints metrics comparing human/birdnet labeled
+    acoustic data assuming the human labels are ground truth
 
-cm = confusion_matrix(y_true, y_pred)
-accuracy = accuracy_score(y_true, y_pred)
-precision = precision_score(y_true, y_pred)
-recall = recall_score(y_true, y_pred)
-f1 = f1_score(y_true, y_pred)
+    Args: path to human labeled csv, path to birdnet labeled csv
+    """
+    scored_data = pd.read_csv(human_labeled)
+    ml_output = pd.read_csv(birdnet_labeled)
 
-print("Confusion Matrix:")
-print(cm)
-print(f"Accuracy: {accuracy:.4f}")
-print(f"Precision: {precision:.4f}")
-print(f"Recall: {recall:.4f}")
-print(f"F1 Score: {f1:.4f}")
+    y_true = scored_data['Label'].map({'yes': 1, 'no': 0}).values
+    y_pred = ml_output['Label'].map({'yes': 1, 'no': 0}).values
 
+    confusion_m = confusion_matrix(y_true, y_pred)
+    accuracy = accuracy_score(y_true, y_pred)
+    precision = precision_score(y_true, y_pred)
+    recall = recall_score(y_true, y_pred)
+    f_1 = f1_score(y_true, y_pred)
+
+    print("Confusion Matrix:")
+    print(confusion_m)
+    print(f"Accuracy: {accuracy:.4f}")
+    print(f"Precision: {precision:.4f}")
+    print(f"Recall: {recall:.4f}")
+    print(f"F1 Score: {f_1:.4f}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Input Directory Path'
+        )
+    parser.add_argument('human_labeled', type=str,
+                        help='Path to human labeled adjusted output')
+    parser.add_argument('birdnet_labeled', type=str,
+                        help='Path to birdnet labeled adjusted output')
+    args = parser.parse_args()
+    main(args.human_labeled, args.birdnet_labeled)

--- a/assess_birdnet/normalize_birdnet_output.py
+++ b/assess_birdnet/normalize_birdnet_output.py
@@ -25,26 +25,26 @@ def main(aggr_birdnet, birdnet_labeled):
     """
     ml_output = pd.read_csv(aggr_birdnet)
 
-    ml_output = ml_output.apply(adjust_time, axis=1)
+    filtered_data = ml_output[ml_output['Common Name'] == 'burowl']
+
+    filtered_data  = filtered_data.apply(adjust_time, axis=1)
 
     # total duration of the sound file(s) that birdnet analyzed
-    total_duration = 3 * 60 * 60
+    total_duration = 10800
     all_intervals = pd.DataFrame({
         'Begin Time (s)': np.arange(0, total_duration, 3),
         'End Time (s)': np.arange(3, total_duration + 3, 3),
     })
-
     all_intervals['Label'] = 'no'
 
-    for _, row in ml_output.iterrows():
+
+    for _, row in filtered_data.iterrows():
         start = row['Begin Time (s)']
         end = row['End Time (s)']
         mask = (
             all_intervals['Begin Time (s)'] >= start
         ) & (all_intervals['End Time (s)'] <= end)
         all_intervals.loc[mask, 'Label'] = 'yes'
-
-    print(all_intervals.head(20))
 
     all_intervals.to_csv(birdnet_labeled, index=False)
 
@@ -62,15 +62,14 @@ def adjust_time(row):
     Args:
         rows: rows in the aggregated birdnet analysis file
     Returns:
-        rows: the adjusted row
+        pandas.Series object: the adjusted row
 
     """
-    chunk_number = int(row['File Name'].split('out')[1].split('.')[0])
-    offset = chunk_number * 600
+    chunk_number = int(row['File Name'].split('output_')[1].split('.')[0])
+    offset = chunk_number * 60
     row['Begin Time (s)'] += offset
     row['End Time (s)'] += offset
     return row
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/assess_birdnet/normalize_birdnet_output.py
+++ b/assess_birdnet/normalize_birdnet_output.py
@@ -1,33 +1,86 @@
+"""Script to adjust birdnet output
+
+This script takes a master csv containing the aggregated birdnet output
+text files and creates an expanded csv containing  a "no" label
+for each chunk of time that birdnet did not detect a vocalization. The
+3-second chunks where birdnet made a detection will be marked with a "yes"
+
+python normalize_birdnet_output.py /path/to/aggregated_birdnet_output.csv
+/path/to/birdnet_labeled.csv
+"""
+import argparse
 import pandas as pd
 import numpy as np
 
-ml_output = pd.read_csv('/home/katie/BirdNET-Analyzer/analyze_audio/analyze_audio_master.csv')
+
+def main(aggr_birdnet, birdnet_labeled):
+    """Main function to take birdnet labels and create a
+    dataframe that has time chunks for the whole audio file
+    duration and labels the detection periods with "yes"
+
+    Args:
+        aggr_birdnet: aggregated birdnet analysis file
+        birdnet_labeled: path to desired output csv
+
+    """
+    ml_output = pd.read_csv(aggr_birdnet)
+
+    ml_output = ml_output.apply(adjust_time, axis=1)
+
+    # total duration of the sound file(s) that birdnet analyzed
+    total_duration = 3 * 60 * 60
+    all_intervals = pd.DataFrame({
+        'Begin Time (s)': np.arange(0, total_duration, 3),
+        'End Time (s)': np.arange(3, total_duration + 3, 3),
+    })
+
+    all_intervals['Label'] = 'no'
+
+    for _, row in ml_output.iterrows():
+        start = row['Begin Time (s)']
+        end = row['End Time (s)']
+        mask = (
+            all_intervals['Begin Time (s)'] >= start
+        ) & (all_intervals['End Time (s)'] <= end)
+        all_intervals.loc[mask, 'Label'] = 'yes'
+
+    print(all_intervals.head(20))
+
+    all_intervals.to_csv(birdnet_labeled, index=False)
+
 
 def adjust_time(row):
+    """Function to standardize the timestamps for the aggregated
+    birdnet input file. This is because this script was designed
+    assuming that the analysis needed to be aggregated from split
+    wav files from the same larger audio recording. This function
+    ensures that if you split up your sound file in smaller bits
+    to be analyzed by birdnet and aggregate their output, the time
+    chunks will represent the entire sound file in order and not
+    as separate audio files.
+
+    Args:
+        rows: rows in the aggregated birdnet analysis file
+    Returns:
+        rows: the adjusted row
+
+    """
     chunk_number = int(row['File Name'].split('out')[1].split('.')[0])
     offset = chunk_number * 600
     row['Begin Time (s)'] += offset
     row['End Time (s)'] += offset
     return row
 
-ml_output = ml_output.apply(adjust_time, axis=1)
 
-total_duration = 3 * 60 * 60
-all_intervals = pd.DataFrame({
-    'Begin Time (s)': np.arange(0, total_duration, 3),
-    'End Time (s)': np.arange(3, total_duration + 3, 3),
-})
-
-all_intervals['Label'] = 'no'
-
-for _, row in ml_output.iterrows():
-    start = row['Begin Time (s)']
-    end = row['End Time (s)']
-    mask = (all_intervals['Begin Time (s)'] >= start) & (all_intervals['End Time (s)'] <= end)
-    all_intervals.loc[mask, 'Label'] = 'yes'
-
-print(all_intervals.head(20))
-
-all_intervals.to_csv('adjusted_ml_output.csv', index=False)
-
-
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Input Directory Path'
+        )
+    parser.add_argument('aggr_birdnet',
+                        type=str,
+                        help='File path to aggregated birdnet raw output')
+    parser.add_argument('birdnet_labeled',
+                        type=str,
+                        help='Result csv with adjusted birdnet results')
+    args = parser.parse_args()
+    main(args.aggr_birdnet, args.birdnet_labeled)

--- a/assess_birdnet/normalize_birdnet_output.py
+++ b/assess_birdnet/normalize_birdnet_output.py
@@ -3,10 +3,13 @@
 This script takes a master csv containing the aggregated birdnet output
 text files and creates an expanded csv containing  a "no" label
 for each chunk of time that birdnet did not detect a vocalization. The
-3-second chunks where birdnet made a detection will be marked with a "yes"
+3-second chunks where birdnet made a detection will be marked with a "yes".
 
-python normalize_birdnet_output.py /path/to/aggregated_birdnet_output.csv
-/path/to/birdnet_labeled.csv
+Example:
+
+    $ python normalize_birdnet_output.py /path/to/aggregated_birdnet_output.csv /path/to/birdnet_labeled.csv
+
+# pylint: disable=line-too-long
 """
 import argparse
 import pandas as pd
@@ -14,20 +17,21 @@ import numpy as np
 
 
 def main(aggr_birdnet, birdnet_labeled):
-    """Main function to take birdnet labels and create a
+    """Organize and expand birdnet labels
+    Main function to take birdnet labels and create a
     dataframe that has time chunks for the whole audio file
-    duration and labels the detection periods with "yes"
+    duration and labels the detection periods with "yes".
 
     Args:
-        aggr_birdnet: aggregated birdnet analysis file
-        birdnet_labeled: path to desired output csv
+        aggr_birdnet (str): aggregated birdnet analysis file
+        birdnet_labeled (str): path to desired output csv
 
     """
     ml_output = pd.read_csv(aggr_birdnet)
 
     filtered_data = ml_output[ml_output['Common Name'] == 'burowl']
 
-    filtered_data  = filtered_data.apply(adjust_time, axis=1)
+    filtered_data = filtered_data.apply(adjust_time, axis=1)
 
     # total duration of the sound file(s) that birdnet analyzed
     total_duration = 10800
@@ -36,7 +40,6 @@ def main(aggr_birdnet, birdnet_labeled):
         'End Time (s)': np.arange(3, total_duration + 3, 3),
     })
     all_intervals['Label'] = 'no'
-
 
     for _, row in filtered_data.iterrows():
         start = row['Begin Time (s)']
@@ -50,7 +53,8 @@ def main(aggr_birdnet, birdnet_labeled):
 
 
 def adjust_time(row):
-    """Function to standardize the timestamps for the aggregated
+    """Continuous timestamps
+    Function to standardize the timestamps for the aggregated
     birdnet input file. This is because this script was designed
     assuming that the analysis needed to be aggregated from split
     wav files from the same larger audio recording. This function
@@ -60,9 +64,10 @@ def adjust_time(row):
     as separate audio files.
 
     Args:
-        rows: rows in the aggregated birdnet analysis file
+        row (pandas.Series object): rows in the aggregated birdnet
+        analysis file
     Returns:
-        pandas.Series object: the adjusted row
+        row (pandas.Series object): the adjusted row
 
     """
     chunk_number = int(row['File Name'].split('output_')[1].split('.')[0])
@@ -70,6 +75,7 @@ def adjust_time(row):
     row['Begin Time (s)'] += offset
     row['End Time (s)'] += offset
     return row
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/assess_birdnet/normalize_scored_output.py
+++ b/assess_birdnet/normalize_scored_output.py
@@ -28,11 +28,11 @@ def main(labels, adjusted_labels):
     scored_data = pd.read_csv(labels)
 
     # need to insert wav file of interest, cannot handle multiple at once
-    file_of_interest = '20170422_180000.wav'
+    file_of_interest = '20170421_180000.wav'
     filtered_data = scored_data[scored_data['IN FILE'] == file_of_interest]
 
     # time length of audio file of interest
-    audio_file_duration = 3 * 60 * 60
+    audio_file_duration = 10800
 
     total_chunks = audio_file_duration // 3
     chunks_data = {
@@ -41,9 +41,8 @@ def main(labels, adjusted_labels):
         'Label': ['no'] * total_chunks
     }
     chunks_df = pd.DataFrame(chunks_data)
-
-    for row in filtered_data:
-        filtered_data.apply(mark_intervals(row, chunks_df),
+    for i, row in filtered_data.iterrows():
+        filtered_data.apply(lambda row: mark_intervals(row, chunks_df),
                             axis=1)
 
     print(chunks_df.head(20))
@@ -62,8 +61,8 @@ def mark_intervals(row, chunks_df):
         chunks_df: the new unlabeled dataframe
 
     """
-    start_time = row['OFFSET']
-    end_time = start_time + row['DURATION']
+    start_time = float(row['OFFSET'])
+    end_time = start_time + float(row['DURATION'])
     start_chunk = int(start_time // 3)
     end_chunk = int(end_time // 3)
 
@@ -75,10 +74,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Input Directory Path'
         )
-    parser.add_argument('human labels',
+    parser.add_argument('labels',
                         type=str,
                         help='File path to human labeled raw output')
-    parser.add_argument('adjusted human label output',
+    parser.add_argument('adjusted_labels',
                         type=str,
                         help='Result csv with adjusted human labels')
     args = parser.parse_args()

--- a/assess_birdnet/normalize_scored_output.py
+++ b/assess_birdnet/normalize_scored_output.py
@@ -1,33 +1,85 @@
+"""Adjust human labeled data
+
+This script takes the human labeled data and will output a
+dataframe containing time chunks for your specific sound file
+of interest and labels for each chunk depending on what
+detections were marked by the human labelers.
+
+python normalize_scored_output.py /path/to/human_labeled.csv
+/path/to/output_dataframe.csv
+
+"""
+import argparse
 import pandas as pd
 
-scored_data = pd.read_csv('/home/katie/Downloads/ChickEmer_2017_LS27A.csv')
 
-file_of_interest = '20170422_180000.wav'
-filtered_data = scored_data[scored_data['IN FILE'] == file_of_interest]
+def main(labels, adjusted_labels):
+    """Main function to create a dataframe with the whole
+    duration of the audio file of interest represented in
+    time chunks labeled 'no' or 'yes' if the human labels
+    marked a vocalization in that specific time chunk
 
-audio_file_duration = 3 * 60 * 60
+    Args:
+        labels: the human labeled data
+        adjusted_labels: the resulting csv dataframe with labels
+    for each 3 second chunk based on the human labels
 
-total_chunks = audio_file_duration // 3
-chunks_data = {
-    'Chunk Start': [i*3 for i in range(total_chunks)],
-    'Chunk End': [(i+1)*3 for i in range(total_chunks)],
-    'Label': ['no'] * total_chunks 
-}
-chunks_df = pd.DataFrame(chunks_data)
+    """
+    scored_data = pd.read_csv(labels)
 
-def mark_intervals(row):
+    # need to insert wav file of interest, cannot handle multiple at once
+    file_of_interest = '20170422_180000.wav'
+    filtered_data = scored_data[scored_data['IN FILE'] == file_of_interest]
+
+    # time length of audio file of interest
+    audio_file_duration = 3 * 60 * 60
+
+    total_chunks = audio_file_duration // 3
+    chunks_data = {
+        'Chunk Start': [i*3 for i in range(total_chunks)],
+        'Chunk End': [(i+1)*3 for i in range(total_chunks)],
+        'Label': ['no'] * total_chunks
+    }
+    chunks_df = pd.DataFrame(chunks_data)
+
+    for row in filtered_data:
+        filtered_data.apply(mark_intervals(row, chunks_df),
+                            axis=1)
+
+    print(chunks_df.head(20))
+
+    chunks_df.to_csv(adjusted_labels, index=False)
+
+
+def mark_intervals(row, chunks_df):
+    """Function to relabel the row in the dataframe
+    to yes if the human labels marked a vocalization
+    at that point
+
+    Args:
+        row: current row in the human labeled data
+    that matches the audio file of interest
+        chunks_df: the new unlabeled dataframe
+
+    """
     start_time = row['OFFSET']
     end_time = start_time + row['DURATION']
     start_chunk = int(start_time // 3)
     end_chunk = int(end_time // 3)
-    
+
     if row['TOP1MATCH'] != 'null':
         chunks_df.loc[start_chunk:end_chunk, 'Label'] = 'yes'
 
-filtered_data.apply(mark_intervals, axis=1)
 
-print(chunks_df.head(20))
-
-chunks_df.to_csv('formatted_data_for_20170422_180000.csv', index=False)
-
-
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Input Directory Path'
+        )
+    parser.add_argument('human labels',
+                        type=str,
+                        help='File path to human labeled raw output')
+    parser.add_argument('adjusted human label output',
+                        type=str,
+                        help='Result csv with adjusted human labels')
+    args = parser.parse_args()
+    main(args.labels, args.adjusted_labels)

--- a/assess_birdnet/normalize_scored_output.py
+++ b/assess_birdnet/normalize_scored_output.py
@@ -5,24 +5,26 @@ dataframe containing time chunks for your specific sound file
 of interest and labels for each chunk depending on what
 detections were marked by the human labelers.
 
-python normalize_scored_output.py /path/to/human_labeled.csv
-/path/to/output_dataframe.csv
+Example:
+    $ python normalize_scored_output.py /path/to/human_labeled.csv /path/to/output_dataframe.csv
 
+# pylint: disable=line-too-long
 """
 import argparse
 import pandas as pd
 
 
 def main(labels, adjusted_labels):
-    """Main function to create a dataframe with the whole
+    """Organize and expand human labeled data
+    Main function to create a dataframe with the whole
     duration of the audio file of interest represented in
     time chunks labeled 'no' or 'yes' if the human labels
-    marked a vocalization in that specific time chunk
+    marked a vocalization in that specific time chunk.
 
     Args:
-        labels: the human labeled data
-        adjusted_labels: the resulting csv dataframe with labels
-    for each 3 second chunk based on the human labels
+        labels (str): The path to the human labeled data.
+        adjusted_labels (str): The resulting csv dataframe with
+        labels for each 3 second chunk based on the human labels.
 
     """
     scored_data = pd.read_csv(labels)
@@ -41,24 +43,23 @@ def main(labels, adjusted_labels):
         'Label': ['no'] * total_chunks
     }
     chunks_df = pd.DataFrame(chunks_data)
-    for i, row in filtered_data.iterrows():
-        filtered_data.apply(lambda row: mark_intervals(row, chunks_df),
-                            axis=1)
-
-    print(chunks_df.head(20))
+    filtered_data.apply(lambda row: mark_intervals(row, chunks_df),
+                        axis=1)
 
     chunks_df.to_csv(adjusted_labels, index=False)
+    print(f"File {adjusted_labels} created successfully.")
 
 
 def mark_intervals(row, chunks_df):
-    """Function to relabel the row in the dataframe
+    """Labeling detections
+    Function to relabel the row in the dataframe
     to yes if the human labels marked a vocalization
-    at that point
+    at that point.
 
     Args:
-        row: current row in the human labeled data
-    that matches the audio file of interest
-        chunks_df: the new unlabeled dataframe
+        row (pandas.Series object): The current row in the human labeled
+        data that matches the audio file of interest.
+        chunks_df (pandas.Dataframe object): The new unlabeled dataframe.
 
     """
     start_time = float(row['OFFSET'])


### PR DESCRIPTION
This began as a lint pass, but I realized that birdnet had adjusted their output format from when these scripts were created to handle the previous format. They now include an extra class 'nocall' even when filtering for burrowing owl only calls. These needed to be parsed out and dealt with in addition to the linting. Arg parsing was added to all the scripts to make then easier to run from the command line. There are still a few spots where the user needs to adjust some numbers based on their example, but the current numbers are set for a specific example. Both of the normalization scripts require this user input, and are based on the length of your .wav file. Future revisions will obtain the length of the file using tools such as librosa so that the user need not change the code. 