### PR TITLE
43 Update dataframe format to store embeddings as list

### DIFF
--- a/make_model/buowset/embed_to_df_birdnet.py
+++ b/make_model/buowset/embed_to_df_birdnet.py
@@ -35,9 +35,10 @@ def obtain_birdnet_embeddings(embeds):
         filename = ntpath.basename(embed)
         filename = filename.replace(".birdnet.embeddings.txt", ".wav")
         dfb = pd.read_csv(embed,
-                          delimiter="[,\t]",
+                          delimiter="[\t]",
                           engine='python',
                           header=None)
+        dfb[2] = dfb[2].apply(lambda x: [float(i) for i in x.split(',') if i])
         dfb_stripped = dfb.drop(dfb.columns[:2], axis=1)
         flattened = dfb_stripped.values.flatten()
         if len(flattened) > 1024:
@@ -62,7 +63,7 @@ def merge_dfs(metadata, embed_dict):
     embed_df.index.name = 'segment'
     df_merged = metadata.merge(embed_df, on='segment')
     df_merged = df_merged.drop(columns=['segment_duration_s'])
-
+    df_merged = df_merged.rename(columns={0: 'embedding'})
     return df_merged
 
 

--- a/make_model/buowset/embed_to_df_birdnet.py
+++ b/make_model/buowset/embed_to_df_birdnet.py
@@ -39,7 +39,7 @@ def obtain_birdnet_embeddings(embeds):
                           engine='python',
                           header=None)
         dfb[2] = dfb[2].apply(lambda x: [float(i) for i in x.split(',') if i])
-        dfb_stripped = dfb.drop(dfb.columns[:2], axis=1)
+        dfb_stripped = dfb.iloc[:, 2:]
         flattened = dfb_stripped.values.flatten()
         if len(flattened) > 1024:
             print(f"filename {filename} has extra lines. Trunicating")

--- a/make_model/buowset/make_svm.py
+++ b/make_model/buowset/make_svm.py
@@ -61,11 +61,9 @@ def make_x_and_y(embed_df):
     train_df = embed_df[embed_df['fold'].isin(TRAINING_FOLDS)]
     test_df = embed_df[embed_df['fold'].isin(TESTING_FOLDS)]
 
-    embedding_cols = embed_df.select_dtypes(include='float64').columns.tolist()
-
-    x_train = train_df[embedding_cols].values
+    x_train = list(train_df['embedding'].values)
     y_train = train_df['binary_label'].values
-    x_test = test_df[embedding_cols].values
+    x_test = list(test_df['embedding'].values)
     y_test = test_df['binary_label'].values
 
     return x_train, y_train, x_test, y_test


### PR DESCRIPTION
Update embedding dataframe format to store embeddings as a list of floats in a single column instead of one column per feature. This ensures that dataframes coming from different embedding sources (birdnet, perch, etc) can alll have the same structure. 

New structure:
![image](https://github.com/user-attachments/assets/bf90034e-f33d-4dde-a3d0-65e100cb2061)
